### PR TITLE
feat: Add function to delete nodes by UUID

### DIFF
--- a/src/db/group.rs
+++ b/src/db/group.rs
@@ -241,6 +241,28 @@ impl Group {
         }
     }
 
+    /// Recursively remove a node from this group or its children
+    pub fn remove_node_by_uuid(&mut self, uuid: &Uuid) -> Option<Node> {
+        // First, check direct children
+        if let Some(index) = self.children.iter().position(|child| match child {
+            Node::Group(g) => &g.uuid == uuid,
+            Node::Entry(e) => &e.uuid == uuid,
+        }) {
+            return Some(self.children.remove(index));
+        }
+
+        // If not found in direct children, recurse into subgroups
+        for child in &mut self.children {
+            if let Node::Group(g) = child {
+                if let Some(removed_node) = g.remove_node_by_uuid(uuid) {
+                    return Some(removed_node);
+                }
+            }
+        }
+
+        None
+    }
+
     /// Convenience method for getting the name of the Group
     pub fn get_name(&self) -> &str {
         &self.name

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -138,6 +138,35 @@ impl Database {
         }
     }
 
+    /// Deletes a node (entry or group) from the database by its UUID.
+    ///
+    /// # Arguments
+    ///
+    /// * `uuid` - The UUID of the node to delete.
+    /// * `log_deletion` - If true, the deletion will be logged in the `deleted_objects` list,
+    ///   which is important for merging databases.
+    ///
+    /// # Returns
+    ///
+    /// `Some(Node)` containing the deleted node if it was found, otherwise `None`.
+    pub fn delete_by_uuid(&mut self, uuid: &Uuid, log_deletion: bool) -> Option<Node> {
+        if let Some(removed_node) = self.root.remove_node_by_uuid(uuid) {
+            if log_deletion {
+                let uuid_to_log = match &removed_node {
+                    Node::Group(g) => g.uuid,
+                    Node::Entry(e) => e.uuid,
+                };
+                self.deleted_objects.objects.push(DeletedObject {
+                    uuid: uuid_to_log,
+                    deletion_time: Times::now(),
+                });
+            }
+            Some(removed_node)
+        } else {
+            None
+        }
+    }
+
     /// Merge this database with another version of this same database.
     /// This function will use the UUIDs to detect that entries and groups are
     /// the same.

--- a/tests/deletion_tests.rs
+++ b/tests/deletion_tests.rs
@@ -1,0 +1,90 @@
+use keepass::{
+    db::{Entry, Group, Node},
+    Database,
+};
+use uuid::Uuid;
+
+#[test]
+fn test_deletion() {
+    // 1. Setup
+    let mut db = Database::new(Default::default());
+
+    let mut g1 = Group::new("G1");
+    let e1 = Entry::new();
+    let _e1_uuid = e1.uuid;
+    g1.add_child(e1);
+
+    let mut g2 = Group::new("G2");
+    let e2 = Entry::new();
+    let e2_uuid = e2.uuid;
+    g2.add_child(e2);
+    g1.add_child(g2);
+
+    let g1_uuid = g1.uuid;
+    db.root.add_child(g1);
+
+    let e3 = Entry::new();
+    let e3_uuid = e3.uuid;
+    db.root.add_child(e3);
+
+    // 2. Test deleting a nested entry with logging
+    let deleted_node = db.delete_by_uuid(&e2_uuid, true);
+    assert!(deleted_node.is_some());
+    if let Some(Node::Entry(e)) = deleted_node {
+        assert_eq!(e.uuid, e2_uuid);
+    } else {
+        panic!("Expected an Entry to be deleted");
+    }
+
+    // Verify it's gone from the group
+    let g1_ref = db.root.children.iter().find(|n| match n {
+        Node::Group(g) => g.uuid == g1_uuid,
+        _ => false,
+    }).unwrap();
+    if let Node::Group(g) = g1_ref {
+        let g2_ref = g.children.iter().find(|n| match n {
+            Node::Group(g_inner) => g_inner.name == "G2",
+            _ => false,
+        }).unwrap();
+        if let Node::Group(g2_inner) = g2_ref {
+             assert_eq!(g2_inner.children.len(), 0);
+        } else {
+            panic!("Expected G2 group");
+        }
+    } else {
+        panic!("Expected G1 group");
+    }
+
+
+    // Verify it's in deleted_objects
+    assert_eq!(db.deleted_objects.objects.len(), 1);
+    assert_eq!(db.deleted_objects.objects[0].uuid, e2_uuid);
+
+    // 3. Test deleting a group without logging
+    let deleted_node = db.delete_by_uuid(&g1_uuid, false);
+    assert!(deleted_node.is_some());
+    if let Some(Node::Group(g)) = deleted_node {
+        assert_eq!(g.uuid, g1_uuid);
+        // check that it contained e1 and g2 before it was deleted
+        assert_eq!(g.children.len(), 2);
+    } else {
+        panic!("Expected a Group to be deleted");
+    }
+
+    // Verify it's gone from the root
+    assert_eq!(db.root.children.len(), 1);
+    if let Some(Node::Entry(e)) = db.root.children.get(0) {
+        assert_eq!(e.uuid, e3_uuid);
+    } else {
+        panic!("Expected E3 to be the only child of root");
+    }
+
+    // Verify deleted_objects count has not changed
+    assert_eq!(db.deleted_objects.objects.len(), 1);
+
+    // 4. Test deleting a non-existent node
+    let random_uuid = Uuid::new_v4();
+    let deleted_node = db.delete_by_uuid(&random_uuid, true);
+    assert!(deleted_node.is_none());
+    assert_eq!(db.deleted_objects.objects.len(), 1);
+}


### PR DESCRIPTION
This commit introduces a new public method `Database::delete_by_uuid` to allow deleting entries and groups from the database using their UUID.

The new function takes a UUID and a `log_deletion` boolean flag as arguments. If `log_deletion` is set to true, the UUID of the deleted node is added to the `deleted_objects` list, which is important for ensuring that deletions are correctly handled when merging different versions of the database file.

The core deletion logic is implemented in a new recursive method, `Group::remove_node_by_uuid`, which can locate and remove a node from any level of the group hierarchy.

A new integration test file, `tests/deletion_tests.rs`, has been added to provide comprehensive verification of the new functionality, including tests for deleting entries, deleting groups, and respecting the `log_deletion` flag.